### PR TITLE
職歴の追加・更新・削除のツールを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ LAPRAS_API_KEYは職歴関連のツールを使う場合のみ必要です。htt
 LAPRASで職歴を取得して、私に合いそうな求人を探してください。
 ```
 
-（以下開発中）
-
 #### 職歴を更新する例
 
 ```
@@ -116,6 +114,18 @@ https://github.com/user-attachments/assets/9c61470f-f97d-4e6f-97ca-53718c796376
 ### `get_experiences` 職歴一覧取得
 - LAPRASに登録されている職歴情報の一覧を取得
 - 使用例: `get_experiences` ツールを呼び出し、登録済みの職歴一覧を取得
+
+### `create_experience` 職歴新規追加
+- LAPRASに新しい職歴情報を追加
+- 使用例: `create_experience` ツールを呼び出し、新しい職歴を登録
+
+### `update_experience` 職歴更新
+- LAPRASに登録されている職歴情報を更新
+- 使用例: `update_experience` ツールを呼び出し、既存の職歴を更新
+
+### `delete_experience` 職歴削除
+- LAPRASに登録されている職歴情報を削除
+- 使用例: `delete_experience` ツールを呼び出し、指定した職歴を削除
 
 > [!NOTE]
 > 職歴関連のツールを使用するには、LAPRAS_API_KEYの設定が必要です。

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,21 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CreateExperienceTool } from "./tools/createExperience.js";
+import { DeleteExperienceTool } from "./tools/deleteExperience.js";
 import { GetExpriencesTool } from "./tools/getExperiences.js";
 import { GetJobDetailTool } from "./tools/getJobDetail.js";
 import { SearchJobsTool } from "./tools/searchJobs.js";
+import { UpdateExperienceTool } from "./tools/updateExperience.js";
 import type { IMCPTool } from "./types.js";
 
 export const ALL_TOOLS: IMCPTool[] = [
   new SearchJobsTool(), // 求人検索ツール
   new GetJobDetailTool(), // 求人詳細取得ツール
   new GetExpriencesTool(), // 職歴取得ツール
+  new CreateExperienceTool(), // 職歴新規追加ツール
+  new UpdateExperienceTool(), // 職歴更新ツール
+  new DeleteExperienceTool(), // 職歴削除ツール
 ];
 
 const server = new McpServer(

--- a/src/tools/__tests__/createExperience.test.ts
+++ b/src/tools/__tests__/createExperience.test.ts
@@ -44,9 +44,9 @@ describe("CreateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     };
 
     mockFetch.mockResolvedValueOnce({
@@ -82,9 +82,9 @@ describe("CreateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
+      position_name: "",
       client_company_name: "Client Company",
-      description: undefined,
+      description: "",
     };
 
     mockFetch.mockResolvedValueOnce({
@@ -115,9 +115,9 @@ describe("CreateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     });
 
     expect(result.isError).toBe(true);
@@ -141,9 +141,9 @@ describe("CreateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     });
 
     expect(result.isError).toBe(true);

--- a/src/tools/__tests__/createExperience.test.ts
+++ b/src/tools/__tests__/createExperience.test.ts
@@ -1,0 +1,155 @@
+import fetch from "node-fetch";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateExperienceTool } from "../createExperience.js";
+
+vi.mock("node-fetch", () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+describe("CreateExperienceTool", () => {
+  let tool: CreateExperienceTool;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    tool = new CreateExperienceTool();
+    mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+    process.env = { ...originalEnv, LAPRAS_API_KEY: "test-api-key" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    process.env = originalEnv;
+  });
+
+  it("職歴を正常に作成できる", async () => {
+    const mockData = {
+      id: "123",
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+    };
+
+    const createParams = {
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await tool.execute(createParams);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual(mockData);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          Authorization: "Bearer test-api-key",
+        },
+        body: JSON.stringify(createParams),
+      }),
+    );
+  });
+
+  it("クライアントワークの場合、client_company_nameが必須", async () => {
+    const createParams = {
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: true,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: "Client Company",
+      description: undefined,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...createParams, id: "123" }),
+    });
+
+    const result = await tool.execute(createParams);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(createParams),
+      }),
+    );
+  });
+
+  it("LAPRAS_API_KEYが設定されていない場合はエラーを返す", async () => {
+    process.env.LAPRAS_API_KEY = undefined;
+
+    const result = await tool.execute({
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("LAPRAS_API_KEYの設定が必要です");
+  });
+
+  it("APIリクエストが失敗した場合はエラーを返す", async () => {
+    const originalConsoleError = console.error;
+    console.error = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+    });
+
+    const result = await tool.execute({
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("職歴の新規追加に失敗しました");
+    expect(console.error).toHaveBeenCalled();
+
+    console.error = originalConsoleError;
+  });
+});

--- a/src/tools/__tests__/deleteExperience.test.ts
+++ b/src/tools/__tests__/deleteExperience.test.ts
@@ -1,0 +1,77 @@
+import fetch from "node-fetch";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteExperienceTool } from "../deleteExperience.js";
+
+vi.mock("node-fetch", () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+describe("DeleteExperienceTool", () => {
+  let tool: DeleteExperienceTool;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    tool = new DeleteExperienceTool();
+    mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+    process.env = { ...originalEnv, LAPRAS_API_KEY: "test-api-key" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    process.env = originalEnv;
+  });
+
+  it("職歴を正常に削除できる", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const result = await tool.execute({ experience_id: 123 });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toBe("職歴の削除が完了しました");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "DELETE",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          Authorization: "Bearer test-api-key",
+        },
+      }),
+    );
+  });
+
+  it("LAPRAS_API_KEYが設定されていない場合はエラーを返す", async () => {
+    process.env.LAPRAS_API_KEY = undefined;
+
+    const result = await tool.execute({ experience_id: 123 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("LAPRAS_API_KEYの設定が必要です");
+  });
+
+  it("APIリクエストが失敗した場合はエラーを返す", async () => {
+    const originalConsoleError = console.error;
+    console.error = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const result = await tool.execute({ experience_id: 123 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("職歴の削除に失敗しました");
+    expect(console.error).toHaveBeenCalled();
+
+    console.error = originalConsoleError;
+  });
+});

--- a/src/tools/__tests__/updateExperience.test.ts
+++ b/src/tools/__tests__/updateExperience.test.ts
@@ -45,9 +45,9 @@ describe("UpdateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     };
 
     mockFetch.mockResolvedValueOnce({
@@ -95,9 +95,9 @@ describe("UpdateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     });
 
     expect(result.isError).toBe(true);
@@ -122,9 +122,9 @@ describe("UpdateExperienceTool", () => {
       start_month: 1,
       end_year: 2023,
       end_month: 12,
-      position_name: undefined,
-      client_company_name: undefined,
-      description: undefined,
+      position_name: "",
+      client_company_name: "",
+      description: "",
     });
 
     expect(result.isError).toBe(true);

--- a/src/tools/__tests__/updateExperience.test.ts
+++ b/src/tools/__tests__/updateExperience.test.ts
@@ -78,6 +78,9 @@ describe("UpdateExperienceTool", () => {
           start_month: updateParams.start_month,
           end_year: updateParams.end_year,
           end_month: updateParams.end_month,
+          position_name: updateParams.position_name,
+          client_company_name: updateParams.client_company_name,
+          description: updateParams.description,
         }),
       }),
     );

--- a/src/tools/__tests__/updateExperience.test.ts
+++ b/src/tools/__tests__/updateExperience.test.ts
@@ -1,0 +1,136 @@
+import fetch from "node-fetch";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateExperienceTool } from "../updateExperience.js";
+
+vi.mock("node-fetch", () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+describe("UpdateExperienceTool", () => {
+  let tool: UpdateExperienceTool;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    tool = new UpdateExperienceTool();
+    mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+    process.env = { ...originalEnv, LAPRAS_API_KEY: "test-api-key" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    process.env = originalEnv;
+  });
+
+  it("職歴を正常に更新できる", async () => {
+    const mockData = {
+      id: 123,
+      organization_name: "Updated Company",
+      positions: [{ id: 1 }],
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+    };
+
+    const updateParams = {
+      experience_id: 123,
+      organization_name: "Updated Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await tool.execute(updateParams);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual(mockData);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "PUT",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-api-key",
+        },
+        body: JSON.stringify({
+          organization_name: updateParams.organization_name,
+          positions: updateParams.positions,
+          is_client_work: updateParams.is_client_work,
+          start_year: updateParams.start_year,
+          start_month: updateParams.start_month,
+          end_year: updateParams.end_year,
+          end_month: updateParams.end_month,
+        }),
+      }),
+    );
+  });
+
+  it("LAPRAS_API_KEYが設定されていない場合はエラーを返す", async () => {
+    process.env.LAPRAS_API_KEY = undefined;
+
+    const result = await tool.execute({
+      experience_id: 123,
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("LAPRAS_API_KEYの設定が必要です");
+  });
+
+  it("APIリクエストが失敗した場合はエラーを返す", async () => {
+    const originalConsoleError = console.error;
+    console.error = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+    });
+
+    const result = await tool.execute({
+      experience_id: 123,
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: undefined,
+      client_company_name: undefined,
+      description: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("職歴の更新に失敗しました");
+    expect(console.error).toHaveBeenCalled();
+
+    console.error = originalConsoleError;
+  });
+});

--- a/src/tools/createExperience.ts
+++ b/src/tools/createExperience.ts
@@ -55,7 +55,7 @@ export class CreateExperienceTool implements IMCPTool {
     end_month: z.number().describe("End month (0 if ongoing)"),
     description: z
       .string()
-      .optional()
+      .default("")
       .describe("Detailed description of the experience (Markdown format)"),
   } as const;
 

--- a/src/tools/createExperience.ts
+++ b/src/tools/createExperience.ts
@@ -1,0 +1,95 @@
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { BASE_URL } from "../constants.js";
+import { createErrorResponse } from "../helpers/createErrorResponse.js";
+import { validateApiKey } from "../helpers/validateApiKey.js";
+import type { IMCPTool, InferZodParams } from "../types.js";
+
+/**
+ * 職歴新規追加ツール
+ */
+export class CreateExperienceTool implements IMCPTool {
+  /**
+   * Tool name
+   */
+  readonly name = "create_experience";
+
+  /**
+   * Tool description
+   */
+  readonly description =
+    "Create a new work experience on LAPRAS(https://lapras.com). You can check the result at https://lapras.com/cv";
+
+  /**
+   * Parameter definition
+   */
+  readonly parameters = {
+    organization_name: z.string().describe("Name of the organization"),
+    positions: z
+      .array(
+        z.object({
+          id: z
+            .number()
+            .describe(
+              "Position type ID (1: フロントエンドエンジニア, 2: バックエンドエンジニア, 3: Webアプリケーションエンジニア, 4: インフラエンジニア, 5: SRE, 6: Android アプリエンジニア, 7: iOS アプリエンジニア, 8: モバイルエンジニア, 9: 機械学習エンジニア, 10: データサイエンティスト, 11: プロジェクトマネージャー, 12: プロダクトマネージャー, 13: テックリード, 14: エンジニアリングマネージャー, 15: リサーチエンジニア, 16: QA・テストエンジニア, 17: アーキテクト, 18: システムエンジニア, 19: 組み込みエンジニア, 20: データベースエンジニア, 21: ネットワークエンジニア, 22: セキュリティエンジニア, 23: スクラムマスター, 24: ゲームエンジニア, 25: CTO, 26: コーポレートエンジニア, 27: デザイナーその他, 28: データエンジニア, 29: CRE・テクニカルサポート, 30: セールスエンジニア・プリセールス, 32: ITエンジニアその他, 33: UI/UXデザイナー, 34: Webデザイナー, 35: ゲームデザイナー, 36: 動画制作・編集, 37: Webプロデューサー・ディレクター, 38: Webコンテンツ企画・編集・ライティング, 39: ゲームプロデューサー・ディレクター, 40: プロダクトマーケティングマネージャー, 41: 動画プロデューサー・ディレクター, 42: アートディレクター, 43: PM/ディレクターその他, 44: 営業, 45: 法人営業, 46: 個人営業, 47: 営業企画, 48: 営業事務, 49: 代理店営業, 50: インサイドセールス, 51: セールスその他, 52: 事業企画, 53: 経営企画, 54: 新規事業開発, 55: 事業開発その他, 56: カスタマーサクセス, 57: カスタマーサポート, 58: ヘルプデスク, 59: コールセンター管理・運営, 60: カスタマーサクセス・サポートその他, 61: 広報・PR・広告宣伝, 62: リサーチ・データ分析, 63: 商品企画・開発, 64: 販促, 65: MD・VMD・バイヤー, 66: Web広告運用・SEO・SNS運用, 67: CRM, 68: 広報・マーケティングその他, 69: 経営者・CEO・COO等, 70: CFO, 71: CIO, 72: 監査役, 73: 経営・CXOその他, 74: 経理, 75: 財務, 76: 法務, 77: 総務, 78: 労務, 79: 秘書, 80: 事務, 81: コーポレートその他, 82: 採用, 83: 人材開発・人材育成・研修, 84: 制度企画・組織開発, 85: 労務・給与, 86: 人事その他, 87: システムコンサルタント, 88: パッケージ導入コンサルタント, 89: セキュリティコンサルタント, 90: ネットワークコンサルタント, 91: ITコンサルタントその他, 92: 戦略コンサルタント, 93: DXコンサルタント, 94: 財務・会計コンサルタント, 95: 組織・人事コンサルタント, 96: 業務プロセスコンサルタント, 97: 物流コンサルタント, 98: リサーチャー・調査員, 99: コンサルタントその他, 100: その他)",
+            ),
+        }),
+      )
+      .describe(
+        "List of position type IDs - multiple selections are allowed. Please set relevant position types.",
+      ),
+    position_name: z.string().optional().describe("Position title"),
+    is_client_work: z
+      .boolean()
+      .describe(
+        "Whether this is client work (Set to true when the affiliated company and the project client are different, such as in contract development companies)",
+      ),
+    client_company_name: z
+      .string()
+      .optional()
+      .describe("Client company name (required only when is_client_work is true)"),
+    start_year: z.number().describe("Start year"),
+    start_month: z.number().describe("Start month"),
+    end_year: z.number().describe("End year (0 if ongoing)"),
+    end_month: z.number().describe("End month (0 if ongoing)"),
+    description: z
+      .string()
+      .optional()
+      .describe("Detailed description of the experience (Markdown format)"),
+  } as const;
+
+  /**
+   * Execute function
+   */
+  async execute(args: InferZodParams<typeof this.parameters>): Promise<{
+    content: TextContent[];
+    isError?: boolean;
+  }> {
+    const apiKeyResult = validateApiKey();
+    if (apiKeyResult.isInvalid) return apiKeyResult.errorResopnse;
+
+    try {
+      const response = await fetch(new URL(`${BASE_URL}/experiences`), {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          Authorization: `Bearer ${apiKeyResult.apiKey}`,
+        },
+        body: JSON.stringify(args),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    } catch (error) {
+      console.error(error);
+      return createErrorResponse(error, "職歴の新規追加に失敗しました");
+    }
+  }
+}

--- a/src/tools/createExperience.ts
+++ b/src/tools/createExperience.ts
@@ -39,7 +39,7 @@ export class CreateExperienceTool implements IMCPTool {
       .describe(
         "List of position type IDs - multiple selections are allowed. Please set relevant position types.",
       ),
-    position_name: z.string().optional().describe("Position title"),
+    position_name: z.string().default("").describe("Position title"),
     is_client_work: z
       .boolean()
       .describe(

--- a/src/tools/deleteExperience.ts
+++ b/src/tools/deleteExperience.ts
@@ -1,0 +1,62 @@
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { BASE_URL } from "../constants.js";
+import { createErrorResponse } from "../helpers/createErrorResponse.js";
+import { validateApiKey } from "../helpers/validateApiKey.js";
+import type { IMCPTool, InferZodParams } from "../types.js";
+
+/**
+ * 職歴削除ツール
+ */
+export class DeleteExperienceTool implements IMCPTool {
+  /**
+   * Tool name
+   */
+  readonly name = "delete_experience";
+
+  /**
+   * Tool description
+   */
+  readonly description =
+    "Delete a work experience from LAPRAS(https://lapras.com). You can check the result at https://lapras.com/cv";
+
+  /**
+   * Parameter definition
+   */
+  readonly parameters = {
+    experience_id: z.number().describe("ID of the experience to delete"),
+  } as const;
+
+  /**
+   * Execute function
+   */
+  async execute(args: InferZodParams<typeof this.parameters>): Promise<{
+    content: TextContent[];
+    isError?: boolean;
+  }> {
+    const apiKeyResult = validateApiKey();
+    if (apiKeyResult.isInvalid) return apiKeyResult.errorResopnse;
+
+    try {
+      const response = await fetch(new URL(`${BASE_URL}/experiences/${args.experience_id}`), {
+        method: "DELETE",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          Authorization: `Bearer ${apiKeyResult.apiKey}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status: ${response.status}`);
+      }
+
+      return {
+        content: [{ type: "text", text: "職歴の削除が完了しました" }],
+      };
+    } catch (error) {
+      console.error(error);
+      return createErrorResponse(error, "職歴の削除に失敗しました");
+    }
+  }
+}

--- a/src/tools/updateExperience.ts
+++ b/src/tools/updateExperience.ts
@@ -1,0 +1,99 @@
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { BASE_URL } from "../constants.js";
+import { createErrorResponse } from "../helpers/createErrorResponse.js";
+import { validateApiKey } from "../helpers/validateApiKey.js";
+import type { IMCPTool, InferZodParams } from "../types.js";
+
+/**
+ * 職歴更新ツール
+ */
+export class UpdateExperienceTool implements IMCPTool {
+  /**
+   * Tool name
+   */
+  readonly name = "update_experience";
+
+  /**
+   * Tool description
+   */
+  readonly description =
+    "Update a work experience on LAPRAS(https://lapras.com). You can check the result at https://lapras.com/cv";
+
+  /**
+   * Parameter definition
+   */
+  readonly parameters = {
+    experience_id: z.number().describe("ID of the experience to update"),
+    organization_name: z.string().describe("Name of the organization"),
+    positions: z
+      .array(
+        z.object({
+          id: z
+            .number()
+            .describe(
+              "Position type ID (1: フロントエンドエンジニア, 2: バックエンドエンジニア, 3: Webアプリケーションエンジニア, 4: インフラエンジニア, 5: SRE, 6: Android アプリエンジニア, 7: iOS アプリエンジニア, 8: モバイルエンジニア, 9: 機械学習エンジニア, 10: データサイエンティスト, 11: プロジェクトマネージャー, 12: プロダクトマネージャー, 13: テックリード, 14: エンジニアリングマネージャー, 15: リサーチエンジニア, 16: QA・テストエンジニア, 17: アーキテクト, 18: システムエンジニア, 19: 組み込みエンジニア, 20: データベースエンジニア, 21: ネットワークエンジニア, 22: セキュリティエンジニア, 23: スクラムマスター, 24: ゲームエンジニア, 25: CTO, 26: コーポレートエンジニア, 27: デザイナーその他, 28: データエンジニア, 29: CRE・テクニカルサポート, 30: セールスエンジニア・プリセールス, 32: ITエンジニアその他, 33: UI/UXデザイナー, 34: Webデザイナー, 35: ゲームデザイナー, 36: 動画制作・編集, 37: Webプロデューサー・ディレクター, 38: Webコンテンツ企画・編集・ライティング, 39: ゲームプロデューサー・ディレクター, 40: プロダクトマーケティングマネージャー, 41: 動画プロデューサー・ディレクター, 42: アートディレクター, 43: PM/ディレクターその他, 44: 営業, 45: 法人営業, 46: 個人営業, 47: 営業企画, 48: 営業事務, 49: 代理店営業, 50: インサイドセールス, 51: セールスその他, 52: 事業企画, 53: 経営企画, 54: 新規事業開発, 55: 事業開発その他, 56: カスタマーサクセス, 57: カスタマーサポート, 58: ヘルプデスク, 59: コールセンター管理・運営, 60: カスタマーサクセス・サポートその他, 61: 広報・PR・広告宣伝, 62: リサーチ・データ分析, 63: 商品企画・開発, 64: 販促, 65: MD・VMD・バイヤー, 66: Web広告運用・SEO・SNS運用, 67: CRM, 68: 広報・マーケティングその他, 69: 経営者・CEO・COO等, 70: CFO, 71: CIO, 72: 監査役, 73: 経営・CXOその他, 74: 経理, 75: 財務, 76: 法務, 77: 総務, 78: 労務, 79: 秘書, 80: 事務, 81: コーポレートその他, 82: 採用, 83: 人材開発・人材育成・研修, 84: 制度企画・組織開発, 85: 労務・給与, 86: 人事その他, 87: システムコンサルタント, 88: パッケージ導入コンサルタント, 89: セキュリティコンサルタント, 90: ネットワークコンサルタント, 91: ITコンサルタントその他, 92: 戦略コンサルタント, 93: DXコンサルタント, 94: 財務・会計コンサルタント, 95: 組織・人事コンサルタント, 96: 業務プロセスコンサルタント, 97: 物流コンサルタント, 98: リサーチャー・調査員, 99: コンサルタントその他, 100: その他)",
+            ),
+        }),
+      )
+      .describe(
+        "List of position type IDs - multiple selections are allowed. Please set relevant position types.",
+      ),
+    position_name: z.string().optional().describe("Position title"),
+    is_client_work: z
+      .boolean()
+      .describe(
+        "Whether this is client work (Set to true when the affiliated company and the project client are different, such as in contract development companies)",
+      ),
+    client_company_name: z
+      .string()
+      .optional()
+      .describe("Client company name (required only when is_client_work is true)"),
+    start_year: z.number().describe("Start year"),
+    start_month: z.number().describe("Start month"),
+    end_year: z.number().describe("End year (0 if ongoing)"),
+    end_month: z.number().describe("End month (0 if ongoing)"),
+    description: z
+      .string()
+      .optional()
+      .describe("Detailed description of the experience (Markdown format)"),
+  } as const;
+
+  /**
+   * Execute function
+   */
+  async execute(args: InferZodParams<typeof this.parameters>): Promise<{
+    content: TextContent[];
+    isError?: boolean;
+  }> {
+    const apiKeyResult = validateApiKey();
+    if (apiKeyResult.isInvalid) return apiKeyResult.errorResopnse;
+
+    const { experience_id, ...updateData } = args;
+
+    try {
+      const response = await fetch(new URL(`${BASE_URL}/experiences/${experience_id}`), {
+        method: "PUT",
+        headers: {
+          accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKeyResult.apiKey}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    } catch (error) {
+      console.error(error);
+      return createErrorResponse(error, "職歴の更新に失敗しました");
+    }
+  }
+}

--- a/src/tools/updateExperience.ts
+++ b/src/tools/updateExperience.ts
@@ -40,7 +40,7 @@ export class UpdateExperienceTool implements IMCPTool {
       .describe(
         "List of position type IDs - multiple selections are allowed. Please set relevant position types.",
       ),
-    position_name: z.string().optional().describe("Position title"),
+    position_name: z.string().default("").describe("Position title"),
     is_client_work: z
       .boolean()
       .describe(

--- a/src/tools/updateExperience.ts
+++ b/src/tools/updateExperience.ts
@@ -56,7 +56,7 @@ export class UpdateExperienceTool implements IMCPTool {
     end_month: z.number().describe("End month (0 if ongoing)"),
     description: z
       .string()
-      .optional()
+      .default("")
       .describe("Detailed description of the experience (Markdown format)"),
   } as const;
 


### PR DESCRIPTION
## 概要
LAPRASの職歴情報を管理するため以下の3つのツールを実装しています：

- `create_experience`: 新規職歴の追加
- `update_experience`: 既存職歴の更新
- `delete_experience`: 職歴の削除

## 主な変更点
- 職歴管理用の3つの新規ツールの実装
- 各ツールのユニットテストの追加
- READMEの更新（職歴管理機能の説明追加）

## 動作確認方法
1. LAPRAS_API_KEYを環境変数に設定
2. 各ツールを使用して職歴情報の追加/更新/削除を実行

## 備考
- APIキーは https://lapras.com/config/api-key から取得可能