### PR TITLE
[fix] llm側で改行をエスケープした場合への対処を追加

### DIFF
--- a/src/helpers/__tests__/textFormatter.test.ts
+++ b/src/helpers/__tests__/textFormatter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { unescapeText } from "../textFormatter.js";
+
+describe("unescapeText", () => {
+  it("エスケープされた改行文字を実際の改行に変換する", () => {
+    const input = "Line 1\\nLine 2\\nLine 3";
+    const expected = "Line 1\nLine 2\nLine 3";
+    expect(unescapeText(input)).toBe(expected);
+  });
+
+  it("通常の文字列はそのまま返す", () => {
+    const input = "Normal text without escapes";
+    expect(unescapeText(input)).toBe(input);
+  });
+
+  it("undefinedの場合は空文字列を返す", () => {
+    expect(unescapeText(undefined)).toBe("");
+  });
+
+  it("nullの場合は空文字列を返す", () => {
+    expect(unescapeText(null)).toBe("");
+  });
+
+  it("複数の連続した改行文字を正しく変換する", () => {
+    const input = "Line 1\\n\\nLine 3";
+    const expected = "Line 1\n\nLine 3";
+    expect(unescapeText(input)).toBe(expected);
+  });
+
+  it("タブ文字を正しく変換する", () => {
+    const input = "Column1\\tColumn2\\tColumn3";
+    const expected = "Column1\tColumn2\tColumn3";
+    expect(unescapeText(input)).toBe(expected);
+  });
+
+  it("改行とタブを組み合わせて正しく変換する", () => {
+    const input = "Title\\nColumn1\\tColumn2\\tColumn3\\nData1\\tData2";
+    const expected = "Title\nColumn1\tColumn2\tColumn3\nData1\tData2";
+    expect(unescapeText(input)).toBe(expected);
+  });
+});

--- a/src/helpers/textFormatter.ts
+++ b/src/helpers/textFormatter.ts
@@ -1,0 +1,12 @@
+/**
+ * エスケープされた文字列を実際の文字に変換します
+ * @see https://github.com/lapras-inc/lapras-mcp-server/issues/5
+ */
+export function unescapeText(text: string | undefined | null): string {
+  if (!text) return "";
+
+  // エスケープされた改行文字とタブ文字を実際の文字に変換
+  return text
+    .replace(/\\n/g, "\n") // 改行
+    .replace(/\\t/g, "\t"); // タブ
+}

--- a/src/tools/__tests__/createExperience.test.ts
+++ b/src/tools/__tests__/createExperience.test.ts
@@ -152,4 +152,40 @@ describe("CreateExperienceTool", () => {
 
     console.error = originalConsoleError;
   });
+
+  it("descriptionの\\nを改行文字に変換する", async () => {
+    const createParams = {
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: "",
+      client_company_name: "",
+      description: "Line 1\\nLine 2\\nLine 3",
+    };
+
+    const expectedBody = {
+      ...createParams,
+      description: "Line 1\nLine 2\nLine 3",
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...expectedBody, id: "123" }),
+    });
+
+    const result = await tool.execute(createParams);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(expectedBody),
+      }),
+    );
+  });
 });

--- a/src/tools/__tests__/updateExperience.test.ts
+++ b/src/tools/__tests__/updateExperience.test.ts
@@ -136,4 +136,49 @@ describe("UpdateExperienceTool", () => {
 
     console.error = originalConsoleError;
   });
+
+  it("descriptionの\\nを改行文字に変換する", async () => {
+    const updateParams = {
+      experience_id: 123,
+      organization_name: "Test Company",
+      positions: [{ id: 1 }],
+      is_client_work: false,
+      start_year: 2020,
+      start_month: 1,
+      end_year: 2023,
+      end_month: 12,
+      position_name: "",
+      client_company_name: "",
+      description: "Line 1\\nLine 2\\nLine 3",
+    };
+
+    const expectedBody = {
+      organization_name: updateParams.organization_name,
+      positions: updateParams.positions,
+      is_client_work: updateParams.is_client_work,
+      start_year: updateParams.start_year,
+      start_month: updateParams.start_month,
+      end_year: updateParams.end_year,
+      end_month: updateParams.end_month,
+      position_name: updateParams.position_name,
+      client_company_name: updateParams.client_company_name,
+      description: "Line 1\nLine 2\nLine 3",
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...expectedBody, id: 123 }),
+    });
+
+    const result = await tool.execute(updateParams);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify(expectedBody),
+      }),
+    );
+  });
 });

--- a/src/tools/createExperience.ts
+++ b/src/tools/createExperience.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import { z } from "zod";
 import { BASE_URL } from "../constants.js";
 import { createErrorResponse } from "../helpers/createErrorResponse.js";
+import { unescapeText } from "../helpers/textFormatter.js";
 import { validateApiKey } from "../helpers/validateApiKey.js";
 import type { IMCPTool, InferZodParams } from "../types.js";
 
@@ -76,7 +77,10 @@ export class CreateExperienceTool implements IMCPTool {
           accept: "application/json, text/plain, */*",
           Authorization: `Bearer ${apiKeyResult.apiKey}`,
         },
-        body: JSON.stringify(args),
+        body: JSON.stringify({
+          ...args,
+          description: unescapeText(args.description),
+        }),
       });
 
       if (!response.ok) {

--- a/src/tools/updateExperience.ts
+++ b/src/tools/updateExperience.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import { z } from "zod";
 import { BASE_URL } from "../constants.js";
 import { createErrorResponse } from "../helpers/createErrorResponse.js";
+import { unescapeText } from "../helpers/textFormatter.js";
 import { validateApiKey } from "../helpers/validateApiKey.js";
 import type { IMCPTool, InferZodParams } from "../types.js";
 
@@ -80,7 +81,10 @@ export class UpdateExperienceTool implements IMCPTool {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKeyResult.apiKey}`,
         },
-        body: JSON.stringify(updateData),
+        body: JSON.stringify({
+          ...updateData,
+          description: unescapeText(updateData.description),
+        }),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## 概要
LLMからの出力テキストに含まれるエスケープ文字（`\n`、`\t`）を適切に変換する処理を追加。

## 関連Issue
#5