### PR TITLE
docs(README): Gemini CLIのセットアップ方法を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ Claude Desktopを使用している場合、Desktop Extension（.dxtファイル
 > また、WSL経由でnpxを実行する場合は、envの環境変数は読み取れません。argsで直接環境変数を指定する必要があります。
 > 例: `"args": ["LAPRAS_API_KEY=<YOUR_LAPRAS_API_KEY>", "bash", "-c", "/home/bin/npx @lapras-inc/lapras-mcp-server"]`
 
+### Gemini CLI
+
+GoogleのGemini CLIで利用する場合、上記の「**npx**」セクションにあるJSONコードを、お使いの`settings.json`ファイルに追記します。
+
+設定ファイルは通常、OSごとに以下のパスに配置されています。
+* **Windows**: `C:\Users\<ユーザー名>\.gemini\`
+* **macOS / Linux**: `~/.gemini/`
+
+> [!NOTE]
+> `gemini.conf.toml` を使用する場合は、以下のTOML形式で記述することも可能です。
+> ```toml
+> [mcpServers.lapras]
+> command = "npx"
+> args = ["-y", "@lapras-inc/lapras-mcp-server"]
+> 
+> [mcpServers.lapras.env]
+> LAPRAS_API_KEY = "<YOUR_LAPRAS_API_KEY>"
+> ```
 
 ### Docker
 


### PR DESCRIPTION
## 概要

本PRは、`README.md`にGoogleの**Gemini CLI**からLAPRAS MCP Serverを利用するためのセットアップ方法を追記するものです。

## 変更点

ユーザーが迷わず設定できるよう、既存のドキュメント構成を尊重しつつ、以下の変更を加えました。


1.  **`### Gemini CLI` セクションの新規追加**
    * 新しくGemini CLI専用のセクションを追加しました。
 ## 目的

Gemini CLIはMCP（Model-Context Protocol）をサポートしており、多くのユーザーが利用しています。ドキュメントにセットアップ方法を明記することで、このサーバーの利用者が増え、利便性が向上することを期待します。

ご確認のほど、よろしくお願いいたします。